### PR TITLE
Unify sold2 dataclasses

### DIFF
--- a/kornia/feature/sold2/sold2_detector.py
+++ b/kornia/feature/sold2/sold2_detector.py
@@ -1,6 +1,5 @@
 import math
 import warnings
-from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -9,63 +8,12 @@ from kornia.core import Module, Tensor, concatenate, sin, stack, tensor, where, 
 from kornia.core.check import KORNIA_CHECK_SHAPE
 from kornia.geometry.bbox import nms
 from kornia.utils import dataclass_to_dict, dict_to_dataclass, map_location_to_cpu, torch_meshgrid
+from kornia.utils.structures import DetectorCfg, HeatMapRefineCfg, JunctionRefineCfg, LineDetectorCfg
 
 from .backbones import SOLD2Net
 
 urls: Dict[str, str] = {}
 urls["wireframe"] = "https://www.polybox.ethz.ch/index.php/s/blOrW89gqSLoHOk/download"
-
-
-@dataclass
-class HeatMapRefineCfg:
-    mode: str = "local"
-    ratio: float = 0.2
-    valid_thresh: float = 0.001
-    num_blocks: int = 20
-    overlap_ratio: float = 0.5
-
-
-@dataclass
-class JunctionRefineCfg:
-    num_perturbs: int = 9
-    perturb_interval: float = 0.25
-
-
-@dataclass
-class LineDetectorCfg:
-    detect_thresh: float = 0.5
-    num_samples: int = 64
-    inlier_thresh: float = 0.99
-    use_candidate_suppression: bool = True
-    nms_dist_tolerance: float = 3.0
-    heatmap_low_thresh: float = 0.15
-    heatmap_high_thresh: float = 0.2
-    max_local_patch_radius: float = 3
-    lambda_radius: float = 2.0
-    use_heatmap_refinement: bool = True
-    heatmap_refine_cfg: HeatMapRefineCfg = field(default_factory=HeatMapRefineCfg)
-    use_junction_refinement: bool = True
-    junction_refine_cfg: JunctionRefineCfg = field(default_factory=JunctionRefineCfg)
-
-
-@dataclass
-class BackboneCfg:
-    input_channel: int = 1
-    depth: int = 4
-    num_stacks: int = 2
-    num_blocks: int = 1
-    num_classes: int = 5
-
-
-@dataclass
-class DetectorCfg:
-    backbone_cfg: BackboneCfg = field(default_factory=BackboneCfg)
-    use_descriptor: bool = False
-    grid_size: int = 8
-    keep_border_valid: bool = True
-    detection_thresh: float = 0.0153846  # = 1/65: threshold of junction detection
-    max_num_junctions: int = 500  # maximum number of junctions per image
-    line_detector_cfg: LineDetectorCfg = field(default_factory=LineDetectorCfg)
 
 
 class SOLD2_detector(Module):

--- a/kornia/utils/structures.py
+++ b/kornia/utils/structures.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class HeatMapRefineCfg:
+    mode: str = "local"
+    ratio: float = 0.2
+    valid_thresh: float = 0.001
+    num_blocks: int = 20
+    overlap_ratio: float = 0.5
+
+
+@dataclass
+class JunctionRefineCfg:
+    num_perturbs: int = 9
+    perturb_interval: float = 0.25
+
+
+@dataclass
+class LineDetectorCfg:
+    detect_thresh: float = 0.5
+    num_samples: int = 64
+    inlier_thresh: float = 0.99
+    use_candidate_suppression: bool = True
+    nms_dist_tolerance: float = 3.0
+    heatmap_low_thresh: float = 0.15
+    heatmap_high_thresh: float = 0.2
+    max_local_patch_radius: float = 3
+    lambda_radius: float = 2.0
+    use_heatmap_refinement: bool = True
+    heatmap_refine_cfg: HeatMapRefineCfg = field(default_factory=HeatMapRefineCfg)
+    use_junction_refinement: bool = True
+    junction_refine_cfg: JunctionRefineCfg = field(default_factory=JunctionRefineCfg)
+
+
+@dataclass
+class LineMatcherCfg:
+    cross_check: bool = True
+    num_samples: int = 5
+    min_dist_pts: int = 8
+    top_k_candidates: int = 10
+    grid_size: int = 4
+
+
+@dataclass
+class BackboneCfg:
+    input_channel: int = 1
+    depth: int = 4
+    num_stacks: int = 2
+    num_blocks: int = 1
+    num_classes: int = 5
+
+
+@dataclass
+class DetectorCfg:
+    backbone_cfg: BackboneCfg = field(default_factory=BackboneCfg)
+    use_descriptor: bool = False
+    grid_size: int = 8
+    keep_border_valid: bool = True
+    detection_thresh: float = 0.0153846  # = 1/65: threshold of junction detection
+    max_num_junctions: int = 500  # maximum number of junctions per image
+    line_detector_cfg: LineDetectorCfg = field(default_factory=LineDetectorCfg)
+    line_matcher_cfg: LineMatcherCfg = field(default_factory=LineMatcherCfg)


### PR DESCRIPTION
#### Changes
This is a follow up PR of PR  [#2880](https://github.com/kornia/kornia/pull/2880) (see corresponding [comment](https://github.com/kornia/kornia/pull/2880#pullrequestreview-2004735726)). It Unifies the dataclass configs of `sold2` and `sold2_detector` in a separate file `kornia/feature/sold2/structures.py`.

The update of the `sold2` dataclass will be done in a separate PR.

Fixes #2093

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
